### PR TITLE
Adds workflow_dispatch to triggers for Antora build action

### DIFF
--- a/.github/workflows/antora-build.yml
+++ b/.github/workflows/antora-build.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
+  
 jobs:
   build-and-deploy:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
To allow the manual execution of the Antora build action, this PR adds the workflow_dispatch as trigger event for that GitHub action. 