### PR TITLE
Exclude ame-guide main

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -17,7 +17,7 @@ content:
        tags: '*'
        start_path: documentation/developer-guide
      - url: https://github.com/OpenManufacturingPlatform/sds-aspect-model-editor
-       branches: HEAD
+       branches: ~
        tags: '*'
        start_path: documentation/ame-guide
 ui:


### PR DESCRIPTION
This is necessary because both the v4.0.0 tag and main define the same Antora
component version