### PR TITLE
Fix py sdk version conflict

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -22,7 +22,6 @@ content:
        start_path: documentation/ame-guide
      - url: https://github.com/OpenManufacturingPlatform/sds-sdk-py-aspect-model-loader
        branches: HEAD
-       tags: '*'
        start_path: documentation/python-sdk-guide
 ui:
   bundle:


### PR DESCRIPTION
Since both main and v2.0.0 contain 'master' as version in antora.yml, this will
cause a build failure