### PR TITLE
add reference to ESMF and further docs in index.adoc

### DIFF
--- a/src/docs/modules/ROOT/pages/index.adoc
+++ b/src/docs/modules/ROOT/pages/index.adoc
@@ -1,7 +1,12 @@
 = Semantic Data Structuring Working Group - Documentation 
 :page-layout: tiles
 
-Welcome to the Documentation of the Deliverables of the Semantic Data Structuring Working Group in the Open Manufacturing Platform. For more details on the deliverables see below: 
+Welcome to the Documentation of the Deliverables of the Semantic Data Structuring Working Group in the Open Manufacturing Platform (OMP). 
+
+*The work continues in the https://projects.eclipse.org/projects/dt.esmf/developer[Eclipse Semantic Modeling Framework (ESMF)].*
+
+The Open Manufacturing Platform is getting dissolved by the end of 2022. 
+For more details on the deliverables see below: 
 
 '''
 
@@ -30,4 +35,41 @@ Command line interface to work with Aspect Models: Validate and transform models
 
 [.link]
 xref:sds-developer-guide:tooling-guide:bamm-cli.adoc[BAMM CLI]
+--
+
+[.tile]
+[.icon-cli]
+--
+[.title]
+Aspect Model Editor
+
+[.text]
+The Aspect Model Editor is a visual editor for Aspect Models, which automatically validates the models against the BAMM Aspect Meta Model version.
+
+[.link]
+xref:ame-guide:ROOT:introduction.adoc[Aspect Model Editor]
+--
+
+[.tile]
+[.icon-cli]
+--
+[.title]
+Java SDS SDK
+
+[.text]
+The SDS SDK helps you to build solutions, model your Aspect data, implement your own customized Aspect or want to integrate existing assets and systems within the Java programming language.
+[.link]
+xref:sds-developer-guide:tooling-guide:java-aspect-tooling.adoc[Java SDK]
+--
+
+[.tile]
+[.icon-cli]
+--
+[.title]
+Python SDS SDK
+
+[.text]
+The Python SDK offers functionality which helps software developers to work with Aspect Models in their Python applications.
+[.link]
+xref:python-sdk-guide:ROOT:index.adoc[Python SDK]
 --

--- a/src/docs/modules/ROOT/pages/index.adoc
+++ b/src/docs/modules/ROOT/pages/index.adoc
@@ -3,9 +3,9 @@
 
 Welcome to the Documentation of the Deliverables of the Semantic Data Structuring Working Group in the Open Manufacturing Platform (OMP). 
 
-*The work continues in the https://projects.eclipse.org/projects/dt.esmf/developer[Eclipse Semantic Modeling Framework (ESMF)].*
+*The work continues in the https://projects.eclipse.org/projects/dt.esmf[Eclipse Semantic Modeling Framework (ESMF)].*
 
-The Open Manufacturing Platform is getting dissolved by the end of 2022. 
+The Open Manufacturing Platform is being dissolved by the end of 2022. 
 For more details on the deliverables see below: 
 
 '''


### PR DESCRIPTION
This PR proposes to add a disclaimer referencing to the ESMF project site. The PR further adds references to further documentations in the index.adoc .